### PR TITLE
Google Assistant dashbot user id

### DIFF
--- a/src/Voxa-Dashbot.ts
+++ b/src/Voxa-Dashbot.ts
@@ -22,7 +22,13 @@
 
 import DashbotAnalytics from "dashbot";
 import _ from "lodash";
-import { IVoxaEvent, IVoxaReply, VoxaApp, ITransition } from "voxa";
+import {
+  IVoxaEvent,
+  IVoxaReply,
+  VoxaApp,
+  ITransition,
+  GoogleAssistantEvent,
+} from "voxa";
 import rp from "request-promise";
 import {
   IDashbotRevenueEvent,
@@ -193,6 +199,20 @@ export function register(voxaApp: VoxaApp, config: IVoxaDashbotConfig) {
       };
     }
 
+    if (isGoogleAssistant(voxaEvent)) {
+      voxaEvent.dialogflow.conv.user.storage.dashbotUser = {
+        userId: voxaEvent.user.userId,
+      };
+
+      reply = _.merge({}, reply, {
+        payload: {
+          google: {
+            userStorage: voxaEvent.dialogflow.conv.user._serialize(),
+          },
+        },
+      });
+    }
+
     await Dashbot.logOutgoing(rawEvent, reply);
   }
 
@@ -209,4 +229,10 @@ export function register(voxaApp: VoxaApp, config: IVoxaDashbotConfig) {
 
     return true;
   }
+}
+
+function isGoogleAssistant(
+  voxaEvent: IVoxaEvent
+): voxaEvent is GoogleAssistantEvent {
+  return voxaEvent.platform.name === "google";
 }

--- a/src/Voxa-Dashbot.ts
+++ b/src/Voxa-Dashbot.ts
@@ -200,14 +200,15 @@ export function register(voxaApp: VoxaApp, config: IVoxaDashbotConfig) {
     }
 
     if (isGoogleAssistant(voxaEvent)) {
-      voxaEvent.dialogflow.conv.user.storage.dashbotUser = {
-        userId: voxaEvent.user.userId,
-      };
-
       reply = _.merge({}, reply, {
         payload: {
           google: {
-            userStorage: voxaEvent.dialogflow.conv.user._serialize(),
+            userStorage: JSON.stringify({
+              ...JSON.parse(voxaEvent.dialogflow.conv.user._serialize()),
+              dashbotUser: {
+                userId: voxaEvent.user.userId,
+              },
+            }),
           },
         },
       });

--- a/test/.mocharc.json
+++ b/test/.mocharc.json
@@ -1,1 +1,7 @@
-{}
+{
+  "require": "ts-node/register",
+  "watch-ignore": ["reports", "node_modules", ".git"],
+  "extension": "ts,js,json",
+  "recursive": true,
+  "colors": true
+}

--- a/test/google.spec.ts
+++ b/test/google.spec.ts
@@ -45,7 +45,7 @@ describe("Voxa-Dashbot plugin", () => {
         }
 
         const storage = JSON.parse(storageJSON);
-        return (storage.data.voxa.userId = storage.data.dashbotUser.userId);
+        return (storage.data.voxa.userId = storage.dashbotUser.userId);
       })
       .query(true)
       .reply(200, "MOCK DATA");

--- a/test/google.spec.ts
+++ b/test/google.spec.ts
@@ -34,16 +34,11 @@ describe("Voxa-Dashbot plugin", () => {
   });
 
   it("should set the userStorage.dashbotUser.userId", async () => {
-    console.log("=========================================================");
     nockScope = nock(DASHBOT_URL)
       .post("/track")
       .query(true)
       .reply(200, "MOCK DATA")
       .post("/track", (body) => {
-        console.log(JSON.stringify(body.message, null, 2));
-        console.log(
-          "========================================================="
-        );
         const storageJSON = _.get(body, "message.payload.google.userStorage");
         if (!storageJSON) {
           return false;
@@ -62,7 +57,6 @@ describe("Voxa-Dashbot plugin", () => {
     }));
     voxaApp.onState("input.welcome", spy);
     const reply = await googleAction.execute(launch);
-    console.log(JSON.stringify(reply, null, 2));
 
     expect(spy.called).to.be.true;
     expect(nockScope.isDone()).to.be.true;

--- a/test/google.spec.ts
+++ b/test/google.spec.ts
@@ -1,0 +1,70 @@
+"use strict";
+
+import _ from "lodash";
+import chai from "chai";
+import simple from "simple-mock";
+import nock from "nock";
+import { VoxaApp, GoogleAssistantPlatform } from "voxa";
+
+import { register } from "../src";
+import * as views from "./views";
+import * as launch from "./requests/default-welcome-intent.json";
+
+const expect = chai.expect;
+const DASHBOT_URL = "https://tracker.dashbot.io";
+const dashbotConfig: any = {
+  google: "some_api_key",
+  // debug: true
+};
+
+describe("Voxa-Dashbot plugin", () => {
+  let voxaApp: VoxaApp;
+  let googleAction: GoogleAssistantPlatform;
+  let nockScope: nock.Scope;
+
+  beforeEach(() => {
+    voxaApp = new VoxaApp({ views });
+    register(voxaApp, dashbotConfig);
+    googleAction = new GoogleAssistantPlatform(voxaApp);
+  });
+
+  afterEach(() => {
+    simple.restore();
+    nock.cleanAll();
+  });
+
+  it("should set the userStorage.dashbotUser.userId", async () => {
+    console.log("=========================================================");
+    nockScope = nock(DASHBOT_URL)
+      .post("/track")
+      .query(true)
+      .reply(200, "MOCK DATA")
+      .post("/track", (body) => {
+        console.log(JSON.stringify(body.message, null, 2));
+        console.log(
+          "========================================================="
+        );
+        const storageJSON = _.get(body, "message.payload.google.userStorage");
+        if (!storageJSON) {
+          return false;
+        }
+
+        const storage = JSON.parse(storageJSON);
+        return (storage.data.voxa.userId = storage.data.dashbotUser.userId);
+      })
+      .query(true)
+      .reply(200, "MOCK DATA");
+
+    const spy = simple.spy(() => ({
+      say: "LaunchIntent.OpenResponse",
+      flow: "yield",
+      to: "entry",
+    }));
+    voxaApp.onState("input.welcome", spy);
+    const reply = await googleAction.execute(launch);
+    console.log(JSON.stringify(reply, null, 2));
+
+    expect(spy.called).to.be.true;
+    expect(nockScope.isDone()).to.be.true;
+  });
+});

--- a/test/requests/default-welcome-intent.json
+++ b/test/requests/default-welcome-intent.json
@@ -1,0 +1,102 @@
+{
+  "responseId": "221d2bb7-b3ca-43b7-88fd-bd2d33e98770-0f0e27e1",
+  "queryResult": {
+    "queryText": "GOOGLE_ASSISTANT_WELCOME",
+    "action": "input.welcome",
+    "parameters": {},
+    "allRequiredParamsPresent": true,
+    "outputContexts": [
+      {
+        "name": "projects/production/agent/sessions/ABwppHEAp9fwe5dVwOlnu0PUfdVS4jUNSerqiNB20yLtobiIB1dET4KEpFOPvTb-h9U05xP7Gyw9c_Wgve1QyAmxnw/contexts/actions_capability_audio_output"
+      },
+      {
+        "name": "projects/production/agent/sessions/ABwppHEAp9fwe5dVwOlnu0PUfdVS4jUNSerqiNB20yLtobiIB1dET4KEpFOPvTb-h9U05xP7Gyw9c_Wgve1QyAmxnw/contexts/actions_capability_account_linking"
+      },
+      {
+        "name": "projects/production/agent/sessions/ABwppHEAp9fwe5dVwOlnu0PUfdVS4jUNSerqiNB20yLtobiIB1dET4KEpFOPvTb-h9U05xP7Gyw9c_Wgve1QyAmxnw/contexts/actions_capability_screen_output"
+      },
+      {
+        "name": "projects/production/agent/sessions/ABwppHEAp9fwe5dVwOlnu0PUfdVS4jUNSerqiNB20yLtobiIB1dET4KEpFOPvTb-h9U05xP7Gyw9c_Wgve1QyAmxnw/contexts/actions_capability_media_response_audio"
+      },
+      {
+        "name": "projects/production/agent/sessions/ABwppHEAp9fwe5dVwOlnu0PUfdVS4jUNSerqiNB20yLtobiIB1dET4KEpFOPvTb-h9U05xP7Gyw9c_Wgve1QyAmxnw/contexts/google_assistant_input_type_voice"
+      },
+      {
+        "name": "projects/production/agent/sessions/ABwppHEAp9fwe5dVwOlnu0PUfdVS4jUNSerqiNB20yLtobiIB1dET4KEpFOPvTb-h9U05xP7Gyw9c_Wgve1QyAmxnw/contexts/google_assistant_welcome"
+      },
+      {
+        "name": "projects/production/agent/sessions/ABwppHEAp9fwe5dVwOlnu0PUfdVS4jUNSerqiNB20yLtobiIB1dET4KEpFOPvTb-h9U05xP7Gyw9c_Wgve1QyAmxnw/contexts/__system_counters__",
+        "parameters": {
+          "no-input": 0,
+          "no-match": 0
+        }
+      }
+    ],
+    "intent": {
+      "name": "projects/production/agent/intents/42842181-fbf0-583d-b9b4-6e58ca57ba5a",
+      "displayName": "Default Welcome Intent"
+    },
+    "intentDetectionConfidence": 1,
+    "languageCode": "de"
+  },
+  "originalDetectIntentRequest": {
+    "source": "google",
+    "version": "2",
+    "payload": {
+      "user": {
+        "locale": "de-DE",
+        "lastSeen": "2020-05-20T16:24:10Z",
+        "userVerificationStatus": "VERIFIED"
+      },
+      "conversation": {
+        "conversationId": "ABwppHEAp9fwe5dVwOlnu0PUfdVS4jUNSerqiNB20yLtobiIB1dET4KEpFOPvTb-h9U05xP7Gyw9c_Wgve1QyAmxnw",
+        "type": "NEW"
+      },
+      "inputs": [
+        {
+          "intent": "actions.intent.MAIN",
+          "rawInputs": [
+            {
+              "inputType": "VOICE",
+              "query": "Mit test app sprechen"
+            }
+          ]
+        }
+      ],
+      "surface": {
+        "capabilities": [
+          {
+            "name": "actions.capability.AUDIO_OUTPUT"
+          },
+          {
+            "name": "actions.capability.ACCOUNT_LINKING"
+          },
+          {
+            "name": "actions.capability.SCREEN_OUTPUT"
+          },
+          {
+            "name": "actions.capability.MEDIA_RESPONSE_AUDIO"
+          }
+        ]
+      },
+      "isInSandbox": true,
+      "availableSurfaces": [
+        {
+          "capabilities": [
+            {
+              "name": "actions.capability.SCREEN_OUTPUT"
+            },
+            {
+              "name": "actions.capability.AUDIO_OUTPUT"
+            },
+            {
+              "name": "actions.capability.WEB_BROWSER"
+            }
+          ]
+        }
+      ],
+      "requestType": "SIMULATOR"
+    }
+  },
+  "session": "projects/production/agent/sessions/ABwppHEAp9fwe5dVwOlnu0PUfdVS4jUNSerqiNB20yLtobiIB1dET4KEpFOPvTb-h9U05xP7Gyw9c_Wgve1QyAmxnw"
+}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "types": ["node", "mocha"]
+  },
+  "extends": "../tsconfig.json",
+  "include": ["./"]
+}


### PR DESCRIPTION
With google no longer supporting a userid and voxa automatically
generating one, there was a disparity between the user ids stored in
dashbot and those generated by voxa.

This should fix that

https://www.dashbot.io/docs/google/custom-user-metadata/